### PR TITLE
Inheritancelists

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var Mocha = require('mocha'),
     fs = require('fs'),
     path = require('path');
 var mocha = new Mocha({
-    reporter:'json'
+    //reporter:'json'
 });
 mocha.addFile('./util/controlTestRunner.js');
 

--- a/test/test.js
+++ b/test/test.js
@@ -13,7 +13,9 @@ var spawnTest = function(test_file,callback){
         //console.log(data.toString('ascii'))
     });
     controlTest.on('close', function(code) {
+     
         resultString = (last_data.toString('ascii')).slice(1,-2);
+        //console.log(resultString)
         resultCount = {
             pending: parseInt(resultString.split(',')[0].split(':')[1].replace(/ /g,'')),
             passing: parseInt(resultString.split(',')[1].split(':')[1].replace(/ /g,'')),
@@ -42,11 +44,21 @@ startTests = function() {
             done();
         })
     });
-//     it('should pass an example of lists of inheritable dictionaries', function(done) {
-//         spawnTest('./test/testcase_function_configs/testcase_multiple_inherited_lists.js', function(resultCount) {
-            
-//         })
-//     });
+    it('should pass an example of lists of inheritable dictionaries', function(done) {
+        spawnTest('./test/testcase_function_configs/testcase_multiple_inherited_lists.js', function(resultCount) {
+            resultCount.passing.should.equal(3);
+            done()
+        })
+    });
+        
+    it('should run tests on both inherited and implemented', function(done) {
+        spawnTest('./test/testcase_function_configs/testcase_inherited_and_implemented.js', function(resultCount) {
+            resultCount.failing.should.equal(1);
+            done()
+        })
+    });
+    
+    
     it('should download the latest version of the NIST 800-53 Controls', function(done) {
         this.skip()
     });

--- a/test/testcase_function_configs/testcase_1passing_2failing_1pending.js
+++ b/test/testcase_function_configs/testcase_1passing_2failing_1pending.js
@@ -4,7 +4,9 @@ var passing = function(done) {
 var failing = function(done) {
     throw new Error("error");
 }
+
 module.exports.overlay = ['SI_8_1', 'SI_8_2', 'PM_6', 'SC_8_1', 'cr_213']
+
 module.exports.inherited_dict = {
     'SI_8_1': failing
 }

--- a/test/testcase_function_configs/testcase_inherited_and_implemented.js
+++ b/test/testcase_function_configs/testcase_inherited_and_implemented.js
@@ -1,0 +1,23 @@
+var passing = function(done) {
+    done()
+}
+var failing = function(done) {
+    throw new Error("error");
+}
+module.exports.overlay = ['SI_8_1', 'SI_8_2', 'PM_6', 'SC_8_1', 'cr_213']
+
+org_provided_list_1 = {
+    'PM_6': passing
+}
+org_provided_list_2 = {
+    'SI_8_1': passing
+}
+
+module.exports.inherited_dict = {
+    'org1': org_provided_list_1,
+    'org2': org_provided_list_2
+}
+module.exports.implemented_dict = {
+    'PM_6': failing,
+    'SI_8_2': passing
+}

--- a/test/testcase_function_configs/testcase_multiple_inherited_lists.js
+++ b/test/testcase_function_configs/testcase_multiple_inherited_lists.js
@@ -13,7 +13,7 @@ org_provided_list_2 = {
     'SI_8_1': passing
 }
 
-module.exports.inheritance_dict = {
+module.exports.inherited_dict = {
     'org1': org_provided_list_1,
     'org2': org_provided_list_2
 }

--- a/util/controlTestRunner.js
+++ b/util/controlTestRunner.js
@@ -1,7 +1,7 @@
 var Mocha = require('mocha')
 var control_list = require('./controlListParser.js')
 //this function takes the overlay, inherited tests and implemented tests and builds a dictionary 
-var appendInheritedTest = function(provider, control_name, f, test_dict) {
+var appendTest = function(provider, control_name, f, test_dict) {
     if(test_dict.hasOwnProperty(control_name)) { //if it already has a test entry for this control test
         console.log(test_dict)
         test_dict[control_name].push({
@@ -25,13 +25,13 @@ var inheritanceBuilder = function(inheritedTests) {
             //no specified provider
             if(inheritedTests[item].constructor == Function) { //single inherited function
                 console.log('function');
-                test_dict = appendInheritedTest('unknown provider', item, inheritedTests[item], test_dict)
+                test_dict = appendTest('inheritance provider uknown', item, inheritedTests[item], test_dict)
                 //specificed provider
             } else if(inheritedTests[item].constructor == Object) { //checks to see if this is a list of providers
                 controlProvider = inheritedTests[item]
                 controlProviderName = item
                 for(control in controlProvider) {
-                    test_dict = appendInheritedTest(controlProviderName, control, controlProvider[control], test_dict)
+                    test_dict = appendTest('inherited from ' + controlProviderName, control, controlProvider[control], test_dict)
                 }
             }
         }
@@ -41,23 +41,32 @@ var inheritanceBuilder = function(inheritedTests) {
 var assembleTestDict = function(overlay, inheritedTests, implementedTests) {
     var test_dict = {}
     inheritedTests = inheritanceBuilder(inheritedTests)
+    //         if(implementedTests.hasOwnProperty(control_name)) { //checks for implemented tests 
+    //             console.log(test_dict)
+    //             if(test_dict.hasOwnProperty(control_name)) { //if there are inherited tests and implemented tests
+    //                 test_dict = appendTest('implemented by project', control_name, implementedTests[control_name], test_dict)
+    //             }
     for(control in overlay) {
         control_name = overlay[control]
-        if(inheritedTests.hasOwnProperty(control_name)) { //checks first for inherited tests
+        if( inheritedTests.hasOwnProperty(control_name) && implementedTests.hasOwnProperty(control_name)){
             test_dict[control_name] = inheritedTests[control_name];
-        } else if(implementedTests.hasOwnProperty(control_name)) { //checks for implemented tests
+            test_dict = appendTest('suppied test',control_name,implementedTests[control_name], test_dict)
+        } else if(inheritedTests.hasOwnProperty(control_name)) { //checks first for inherited tests
+            test_dict[control_name] = inheritedTests[control_name];
+        } else if(implementedTests.hasOwnProperty(control_name)) {
             test_dict[control_name] = implementedTests[control_name];
         } else {
             test_dict[control_name] = test_pending //adds in pending for potential new tests
         }
     }
+    console.log(test_dict)
     return test_dict
 }
 var executeTest = function(test_name, test) {
     if(undefined !== test) {
         if(test.constructor == Array) { //inheritance parsing
-            for (itest in test){
-                it(test_name+' (inheried from '+test[itest].provider+')',test[itest].f)
+            for(itest in test) {
+                it(test_name + ' (' + test[itest].provider + ')', test[itest].f)
             }
         } else { // an implemented test
             it(test_name, test)


### PR DESCRIPTION
This allows for the passing in of several inheritance lists, as well as prevents implemented control tests conflicted with inherited.  Now mulitple control tests are possible
